### PR TITLE
fix bug : when blur in quick jump, jump to 1

### DIFF
--- a/src/Pagination.jsx
+++ b/src/Pagination.jsx
@@ -190,7 +190,7 @@ class Pagination extends React.Component {
   }
 
   isValid = (page) => {
-    return isInteger(page) && page !== this.state.current;
+    return isInteger(page) && page>=1 && page !== this.state.current;
   }
 
   shouldDisplayQuickJumper = () => {


### PR DESCRIPTION
when blur in quick jump,auto jump to 1,this will cause the pager not work.